### PR TITLE
Build monitoring-first dashboard and retrieval oversight UI

### DIFF
--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -1,67 +1,152 @@
-"""Streamlit monitoring dashboard for the pipeline."""
+"""Streamlit monitoring dashboard for the retrieval oversight workflow."""
 
 from __future__ import annotations
 
-from datetime import datetime, timezone
+import sys
+from pathlib import Path
 
 import streamlit as st
 
-from src.models.documents import AgentEvent
+REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
 
-# --- State ---
-if "events" not in st.session_state:
-    st.session_state.events: list[AgentEvent] = []
+from src.dashboard.components import (
+    render_documents_table,
+    render_event_log,
+    render_global_metrics,
+    render_pipeline_requests,
+    render_retrieval_overview,
+    render_run_history,
+    render_run_summary,
+    render_stage_cards,
+    render_trace_table,
+)
+from src.dashboard.constants import DEFAULT_SOURCE_URL
+from src.dashboard.state import (
+    get_current_run_id,
+    get_run_summary,
+    get_selected_run_id,
+    initialize_state,
+    load_documents,
+    load_events,
+    load_global_metrics,
+    load_pipeline_requests,
+    load_recent_runs,
+    load_retrieval_overview,
+    load_retrieval_trace,
+    load_stage_snapshots,
+    reset_demo_state,
+    select_run,
+    submit_pipeline_request,
+)
 
-if "documents_fetched" not in st.session_state:
-    st.session_state.documents_fetched = 0
-
-if "summaries_generated" not in st.session_state:
-    st.session_state.summaries_generated = 0
-
-
-def add_event(event: AgentEvent):
-    st.session_state.events.append(event)
-
-
-# --- Layout ---
 st.set_page_config(page_title="Westminster Pipeline Monitor", layout="wide")
+initialize_state(st.session_state)
+
 st.title("Westminster Council Pipeline Monitor")
+st.caption("Operations and oversight dashboard for the agent pipeline.")
 
-col1, col2, col3 = st.columns(3)
-col1.metric("Documents Fetched", st.session_state.documents_fetched)
-col2.metric("Summaries Generated", st.session_state.summaries_generated)
-col3.metric("Agent Events", len(st.session_state.events))
+request_col, reset_col = st.columns([3, 1])
+with request_col:
+    with st.form("start-pipeline-form", clear_on_submit=False):
+        source_url = st.text_input(
+            "Pipeline start URL",
+            value=DEFAULT_SOURCE_URL,
+            help="Queue a manual start request for the retrieval pipeline.",
+        )
+        submitted = st.form_submit_button("Queue Pipeline Start", type="primary")
+        if submitted:
+            try:
+                request = submit_pipeline_request(st.session_state, source_url)
+            except ValueError as exc:
+                st.error(str(exc))
+            else:
+                st.success(
+                    f"Queued `{request.request_id}` for `{request.source_url}`. "
+                    "This branch records the request and will hand it to the live retrieval agent later."
+                )
+with reset_col:
+    if st.button("Reset Demo State", use_container_width=True):
+        reset_demo_state(st.session_state)
+        st.rerun()
 
 st.divider()
+render_stage_cards(load_stage_snapshots(st.session_state))
 
-# --- Agent Event Log ---
-st.subheader("Agent Event Log")
+st.divider()
+render_global_metrics(load_global_metrics(st.session_state))
 
-if st.session_state.events:
-    for event in reversed(st.session_state.events):
-        icon = {"started": "🟢", "progress": "🔵", "completed": "✅", "error": "🔴"}.get(
-            event.event_type, "⚪"
-        )
-        st.markdown(
-            f"{icon} **{event.agent_name}** — {event.message}  \n"
-            f"<small>{event.timestamp:%H:%M:%S}</small>",
-            unsafe_allow_html=True,
-        )
+st.divider()
+st.subheader("Queued Pipeline Starts")
+render_pipeline_requests(load_pipeline_requests(st.session_state))
+
+st.divider()
+st.subheader("Current Retrieval Status")
+current_run_id = get_current_run_id(st.session_state)
+recent_runs = load_recent_runs(st.session_state)
+selected_run_id = get_selected_run_id(st.session_state)
+current_overview = load_retrieval_overview(st.session_state, current_run_id)
+
+current_run_summary = get_run_summary(st.session_state, current_run_id)
+if current_run_summary is not None:
+    render_run_summary(current_run_summary, history_mode=False)
 else:
-    st.info("No events yet. Run the pipeline to see activity here.")
+    st.info(
+        "No live retrieval run is active. New URLs are queued here until the retrieval agent "
+        "integration is ready."
+    )
+render_retrieval_overview(current_overview)
 
 st.divider()
-
-# --- Pipeline Controls ---
-st.subheader("Pipeline Controls")
-
-if st.button("Run Retrieval"):
-    add_event(
-        AgentEvent(
-            agent_name="retriever",
-            event_type="started",
-            message="Starting document retrieval...",
-            timestamp=datetime.now(timezone.utc),
-        )
+st.subheader("Historical Retrieval Detail")
+if recent_runs:
+    run_lookup = {run.run_id: run for run in recent_runs}
+    run_labels = {
+        run.run_id: f"{run.run_id} · {run.status.title()} · {run.documents_fetched} docs"
+        for run in recent_runs
+    }
+    selected_index = next(
+        (index for index, run in enumerate(recent_runs) if run.run_id == selected_run_id),
+        0,
     )
-    st.rerun()
+    chosen_run_id = st.selectbox(
+        "Inspect run",
+        options=[run.run_id for run in recent_runs],
+        index=selected_index,
+        format_func=lambda run_id: run_labels[run_id],
+    )
+    if chosen_run_id != selected_run_id:
+        select_run(st.session_state, chosen_run_id)
+        st.rerun()
+
+    selected_run_id = chosen_run_id
+    selected_summary = run_lookup[selected_run_id]
+    render_run_summary(selected_summary, history_mode=True)
+    render_retrieval_overview(load_retrieval_overview(st.session_state, selected_run_id))
+
+    st.markdown("**Retrieval Trace**")
+    render_trace_table(load_retrieval_trace(st.session_state, selected_run_id))
+
+    st.markdown("**Fetched Documents**")
+    render_documents_table(load_documents(st.session_state, selected_run_id))
+else:
+    st.info("No historical retrieval runs are available yet.")
+
+st.divider()
+st.subheader("Recent Runs")
+render_run_history(recent_runs, current_run_id=current_run_id)
+
+st.divider()
+render_event_log(
+    load_events(st.session_state, selected_run_id),
+    title="Selected Run Event Log",
+    empty_message="No events are available for the selected run.",
+)
+
+st.divider()
+render_event_log(
+    load_events(st.session_state),
+    title="Global Event Log",
+    empty_message="No events have been recorded yet.",
+)

--- a/src/dashboard/components.py
+++ b/src/dashboard/components.py
@@ -1,0 +1,199 @@
+"""Rendering helpers for the monitoring dashboard."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any
+
+import streamlit as st
+
+from src.dashboard.state import PipelineRequest, RetrievalTraceStep, RunSummary, StageSnapshot
+from src.models.documents import AgentEvent, CouncilDocument
+
+
+def render_stage_cards(stages: list[StageSnapshot]) -> None:
+    columns = st.columns(len(stages))
+    for column, stage in zip(columns, stages):
+        with column:
+            st.markdown(f"**{stage.label}**")
+            st.metric("Status", format_status(stage.status))
+            st.caption(stage.message)
+            if stage.last_updated is not None:
+                st.caption(f"Updated {format_timestamp(stage.last_updated)}")
+            else:
+                st.caption("No activity yet")
+
+
+def render_global_metrics(metrics: dict[str, Any]) -> None:
+    columns = st.columns(6)
+    labels = (
+        ("Active Run", format_status(str(metrics["active_run_status"]))),
+        ("Docs Discovered", metrics["documents_discovered"]),
+        ("Docs Fetched", metrics["documents_fetched"]),
+        ("Queued Starts", metrics["queued_requests"]),
+        ("Recent Errors", metrics["recent_errors"]),
+        ("Last Run", format_timestamp(metrics["last_run_at"])),
+    )
+    for column, (label, value) in zip(columns, labels):
+        with column:
+            st.metric(label, value)
+
+
+def render_run_summary(summary: RunSummary | None, *, history_mode: bool) -> None:
+    if summary is None:
+        st.info("No retrieval run is available yet.")
+        return
+
+    if history_mode:
+        st.info(f"Inspecting historical run `{summary.run_id}` in read-only mode.")
+
+    col1, col2, col3 = st.columns(3)
+    col1.metric("Run ID", summary.run_id)
+    col2.metric("Status", format_status(summary.status))
+    col3.metric("Documents Fetched", summary.documents_fetched)
+
+    st.caption(
+        "Started "
+        f"{format_timestamp(summary.started_at)}"
+        f" | Completed {format_timestamp(summary.completed_at)}"
+        f" | Errors {summary.errors}"
+    )
+
+
+def render_retrieval_overview(overview: dict[str, Any]) -> None:
+    col1, col2, col3, col4 = st.columns(4)
+    col1.metric("Current Step", format_step_name(overview["current_step"]))
+    col2.metric("Source", truncate_url(overview["current_source_url"]))
+    col3.metric("Discovered", overview["documents_discovered"])
+    col4.metric("Fetched", overview["documents_fetched"])
+
+    active_request = overview.get("active_request")
+    if active_request is not None and overview.get("summary") is None:
+        st.info(
+            f"Manual start request `{active_request.request_id}` is queued for "
+            f"`{active_request.source_url}`."
+        )
+
+    if overview["latest_error"]:
+        st.error(overview["latest_error"])
+
+
+def render_trace_table(trace_steps: list[RetrievalTraceStep]) -> None:
+    if not trace_steps:
+        st.info("No retrieval trace is available for this run.")
+        return
+
+    st.table(
+        [
+            {
+                "Time": format_timestamp(step.timestamp),
+                "Step": format_step_name(step.step_name),
+                "Status": format_status(step.event_type),
+                "Message": step.message,
+                "Document": step.document_title or "—",
+                "Detail": step.detail or "—",
+            }
+            for step in trace_steps
+        ]
+    )
+
+
+def render_documents_table(documents: list[CouncilDocument]) -> None:
+    if not documents:
+        st.info("No documents were fetched for this run.")
+        return
+
+    ordered_documents = sorted(documents, key=lambda document: document.fetched_at, reverse=True)
+    st.table(
+        [
+            {
+                "Fetched At": format_timestamp(document.fetched_at),
+                "Title": document.title,
+                "Type": document.doc_type.value,
+                "Committee": document.committee or "—",
+            }
+            for document in ordered_documents
+        ]
+    )
+
+
+def render_run_history(runs: list[RunSummary], *, current_run_id: str | None) -> None:
+    if not runs:
+        st.info("No run history is available yet.")
+        return
+
+    st.table(
+        [
+            {
+                "Run ID": run.run_id,
+                "View": "Current" if run.run_id == current_run_id else "History",
+                "Status": format_status(run.status),
+                "Started": format_timestamp(run.started_at),
+                "Completed": format_timestamp(run.completed_at),
+                "Docs Fetched": run.documents_fetched,
+                "Errors": run.errors,
+            }
+            for run in runs
+        ]
+    )
+
+
+def render_pipeline_requests(requests: list[PipelineRequest]) -> None:
+    if not requests:
+        st.info("No pipeline start requests have been queued yet.")
+        return
+
+    st.table(
+        [
+            {
+                "Request ID": request.request_id,
+                "Status": format_status(request.status),
+                "Requested At": format_timestamp(request.requested_at),
+                "Source URL": request.source_url,
+                "Message": request.message,
+            }
+            for request in requests
+        ]
+    )
+
+
+def render_event_log(events: list[AgentEvent], *, title: str, empty_message: str) -> None:
+    st.subheader(title)
+    if not events:
+        st.info(empty_message)
+        return
+
+    for event in reversed(events):
+        metadata = event.metadata or {}
+        detail = metadata.get("detail")
+        suffix = f" | {detail}" if detail else ""
+        st.markdown(
+            f"**{format_status(event.event_type)}** `{event.agent_name}`"
+            f" {event.message}  \n"
+            f"<small>{format_timestamp(event.timestamp)}{suffix}</small>",
+            unsafe_allow_html=True,
+        )
+
+
+def format_status(status: str) -> str:
+    return status.replace("_", " ").title() if status else "Unknown"
+
+
+def format_step_name(step_name: str | None) -> str:
+    if not step_name:
+        return "Unknown"
+    return step_name.replace("/", " / ").title()
+
+
+def format_timestamp(value: datetime | None) -> str:
+    if value is None:
+        return "—"
+    return value.strftime("%Y-%m-%d %H:%M:%S UTC")
+
+
+def truncate_url(value: str | None) -> str:
+    if not value:
+        return "—"
+    if len(value) <= 36:
+        return value
+    return value[:33] + "..."

--- a/src/dashboard/constants.py
+++ b/src/dashboard/constants.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+PIPELINE_STAGES = ("retrieval", "analysis", "conversation", "app", "summary")
+
+STAGE_LABELS = {
+    "retrieval": "Retrieval",
+    "analysis": "Analysis",
+    "conversation": "Conversation",
+    "app": "App",
+    "summary": "Summary",
+}
+
+PLACEHOLDER_STAGE_MESSAGE = "Future stage placeholder for monitoring."
+
+DASHBOARD_RUN_EVENTS_KEY = "dashboard_run_events"
+DASHBOARD_RUN_DOCUMENTS_KEY = "dashboard_run_documents"
+DASHBOARD_RUN_ORDER_KEY = "dashboard_run_order"
+DASHBOARD_CURRENT_RUN_KEY = "dashboard_current_run_id"
+DASHBOARD_SELECTED_RUN_KEY = "dashboard_selected_run_id"
+DASHBOARD_RUN_SEQUENCE_KEY = "dashboard_run_sequence"
+DASHBOARD_SUMMARIES_GENERATED_KEY = "dashboard_summaries_generated"
+DASHBOARD_PIPELINE_REQUESTS_KEY = "dashboard_pipeline_requests"
+DASHBOARD_REQUEST_SEQUENCE_KEY = "dashboard_request_sequence"
+
+DEFAULT_SOURCE_URL = "https://committees.westminster.gov.uk/ieDocHome.aspx?Categories="
+HISTORY_LIMIT = 5
+
+RETRIEVAL_METADATA_KEYS = (
+    "run_id",
+    "stage",
+    "step_name",
+    "source_url",
+    "document_url",
+    "document_title",
+    "document_type",
+    "progress_current",
+    "progress_total",
+    "detail",
+)

--- a/src/dashboard/mock_data.py
+++ b/src/dashboard/mock_data.py
@@ -1,0 +1,53 @@
+"""Seed deterministic dashboard state."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from src.dashboard.constants import (
+    DASHBOARD_CURRENT_RUN_KEY,
+    DASHBOARD_PIPELINE_REQUESTS_KEY,
+    DASHBOARD_REQUEST_SEQUENCE_KEY,
+    DASHBOARD_RUN_DOCUMENTS_KEY,
+    DASHBOARD_RUN_EVENTS_KEY,
+    DASHBOARD_RUN_ORDER_KEY,
+    DASHBOARD_RUN_SEQUENCE_KEY,
+    DASHBOARD_SELECTED_RUN_KEY,
+    DASHBOARD_SUMMARIES_GENERATED_KEY,
+)
+from src.dashboard.simulation import create_retrieval_run, next_run_id
+
+
+def create_seeded_dashboard_data() -> dict[str, Any]:
+    """Return deterministic mock state for the monitoring dashboard."""
+    base_time = datetime(2026, 3, 15, 9, 0, tzinfo=timezone.utc)
+    run_specs = (
+        ("completed", base_time),
+        ("error", base_time + timedelta(hours=1)),
+        ("completed", base_time + timedelta(hours=2)),
+    )
+
+    run_events: dict[str, list] = {}
+    run_documents: dict[str, list] = {}
+    run_order: list[str] = []
+
+    for sequence, (outcome, started_at) in enumerate(run_specs, start=1):
+        run_id = next_run_id(sequence)
+        events, documents = create_retrieval_run(run_id, started_at, outcome=outcome)
+        run_order.append(run_id)
+        run_events[run_id] = events
+        run_documents[run_id] = documents
+
+    current_run_id = run_order[-1]
+    return {
+        DASHBOARD_RUN_EVENTS_KEY: run_events,
+        DASHBOARD_RUN_DOCUMENTS_KEY: run_documents,
+        DASHBOARD_RUN_ORDER_KEY: run_order,
+        DASHBOARD_CURRENT_RUN_KEY: None,
+        DASHBOARD_SELECTED_RUN_KEY: current_run_id,
+        DASHBOARD_RUN_SEQUENCE_KEY: len(run_order),
+        DASHBOARD_SUMMARIES_GENERATED_KEY: 0,
+        DASHBOARD_PIPELINE_REQUESTS_KEY: [],
+        DASHBOARD_REQUEST_SEQUENCE_KEY: 0,
+    }

--- a/src/dashboard/simulation.py
+++ b/src/dashboard/simulation.py
@@ -1,0 +1,253 @@
+"""Generate mock retrieval runs for the dashboard."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from src.dashboard.constants import DEFAULT_SOURCE_URL, RETRIEVAL_METADATA_KEYS
+from src.models.documents import AgentEvent, CouncilDocument, DocumentType
+
+DOCUMENT_BLUEPRINTS = (
+    {
+        "slug": "planning-committee-march-2026",
+        "title": "Planning Committee March 2026 Minutes",
+        "doc_type": DocumentType.MINUTES,
+        "committee": "Planning Committee",
+    },
+    {
+        "slug": "cabinet-housing-decision-elm-street",
+        "title": "Cabinet Housing Decision: Elm Street",
+        "doc_type": DocumentType.DECISION,
+        "committee": "Cabinet Member Decisions",
+    },
+    {
+        "slug": "transport-agenda-cycle-lanes",
+        "title": "Transport Committee Agenda: Cycle Lanes",
+        "doc_type": DocumentType.AGENDA,
+        "committee": "Transport Committee",
+    },
+)
+
+
+def next_run_id(sequence_number: int) -> str:
+    return f"run-{sequence_number:03d}"
+
+
+def _base_metadata(run_id: str, step_name: str) -> dict[str, object | None]:
+    return {
+        "run_id": run_id,
+        "stage": "retrieval",
+        "step_name": step_name,
+        "source_url": None,
+        "document_url": None,
+        "document_title": None,
+        "document_type": None,
+        "progress_current": None,
+        "progress_total": None,
+        "detail": None,
+    }
+
+
+def _build_event(
+    *,
+    run_id: str,
+    event_type: str,
+    message: str,
+    timestamp: datetime,
+    step_name: str,
+    source_url: str | None = None,
+    document_url: str | None = None,
+    document_title: str | None = None,
+    document_type: str | None = None,
+    progress_current: int | None = None,
+    progress_total: int | None = None,
+    detail: str | None = None,
+) -> AgentEvent:
+    metadata = _base_metadata(run_id, step_name)
+    metadata.update(
+        {
+            "source_url": source_url,
+            "document_url": document_url,
+            "document_title": document_title,
+            "document_type": document_type,
+            "progress_current": progress_current,
+            "progress_total": progress_total,
+            "detail": detail,
+        }
+    )
+    return AgentEvent(
+        agent_name="retriever",
+        event_type=event_type,
+        message=message,
+        timestamp=timestamp.astimezone(timezone.utc),
+        metadata=metadata,
+    )
+
+
+def _build_document(run_id: str, fetched_at: datetime, blueprint: dict[str, object]) -> CouncilDocument:
+    slug = str(blueprint["slug"])
+    title = str(blueprint["title"])
+    committee = str(blueprint["committee"])
+    doc_type = blueprint["doc_type"]
+    return CouncilDocument(
+        url=f"https://committees.westminster.gov.uk/documents/{run_id}/{slug}.html",
+        title=title,
+        doc_type=doc_type,
+        fetched_at=fetched_at.astimezone(timezone.utc),
+        raw_content=(
+            f"<html><head><title>{title}</title></head>"
+            f"<body><h1>{title}</h1><p>{committee}</p></body></html>"
+        ),
+        committee=committee,
+    )
+
+
+def _document_events(
+    *,
+    run_id: str,
+    source_url: str,
+    document: CouncilDocument,
+    index: int,
+    total: int,
+    started_at: datetime,
+) -> list[AgentEvent]:
+    fetch_time = started_at + timedelta(seconds=index * 20)
+    store_time = fetch_time + timedelta(seconds=6)
+    return [
+        _build_event(
+            run_id=run_id,
+            event_type="progress",
+            message=f"Fetched {document.title}",
+            timestamp=fetch_time,
+            step_name="document fetch",
+            source_url=source_url,
+            document_url=document.url,
+            document_title=document.title,
+            document_type=document.doc_type.value,
+            progress_current=index,
+            progress_total=total,
+            detail="Downloaded council document HTML.",
+        ),
+        _build_event(
+            run_id=run_id,
+            event_type="progress",
+            message=f"Stored {document.title}",
+            timestamp=store_time,
+            step_name="document wrap/store",
+            source_url=source_url,
+            document_url=document.url,
+            document_title=document.title,
+            document_type=document.doc_type.value,
+            progress_current=index,
+            progress_total=total,
+            detail="Wrapped the document in a CouncilDocument model.",
+        ),
+    ]
+
+
+def create_retrieval_run(
+    run_id: str,
+    started_at: datetime,
+    *,
+    source_url: str = DEFAULT_SOURCE_URL,
+    outcome: str = "completed",
+) -> tuple[list[AgentEvent], list[CouncilDocument]]:
+    """Create a deterministic retrieval run for dashboard simulation."""
+    if outcome not in {"completed", "error"}:
+        raise ValueError("outcome must be 'completed' or 'error'")
+
+    started_at = started_at.astimezone(timezone.utc)
+    total_documents = len(DOCUMENT_BLUEPRINTS)
+    events = [
+        _build_event(
+            run_id=run_id,
+            event_type="started",
+            message="Retrieval started",
+            timestamp=started_at,
+            step_name="source discovery",
+            source_url=source_url,
+            detail="Starting retrieval from Westminster committee listings.",
+        ),
+        _build_event(
+            run_id=run_id,
+            event_type="progress",
+            message="Fetched committee source page",
+            timestamp=started_at + timedelta(seconds=8),
+            step_name="page fetch",
+            source_url=source_url,
+            detail="Downloaded the current committee landing page.",
+        ),
+        _build_event(
+            run_id=run_id,
+            event_type="progress",
+            message=f"Parsed {total_documents} candidate documents",
+            timestamp=started_at + timedelta(seconds=15),
+            step_name="link extraction",
+            source_url=source_url,
+            progress_current=total_documents,
+            progress_total=total_documents,
+            detail="Extracted meeting and decision document links.",
+        ),
+    ]
+
+    documents: list[CouncilDocument] = []
+    if outcome == "completed":
+        blueprints = DOCUMENT_BLUEPRINTS
+    else:
+        blueprints = DOCUMENT_BLUEPRINTS[:1]
+
+    for index, blueprint in enumerate(blueprints, start=1):
+        document_time = started_at + timedelta(seconds=20 + index * 20)
+        document = _build_document(run_id, document_time, blueprint)
+        documents.append(document)
+        events.extend(
+            _document_events(
+                run_id=run_id,
+                source_url=source_url,
+                document=document,
+                index=index,
+                total=total_documents,
+                started_at=started_at + timedelta(seconds=20),
+            )
+        )
+
+    if outcome == "error":
+        failed_blueprint = DOCUMENT_BLUEPRINTS[1]
+        failed_url = f"https://committees.westminster.gov.uk/documents/{run_id}/{failed_blueprint['slug']}.html"
+        events.append(
+            _build_event(
+                run_id=run_id,
+                event_type="error",
+                message="Document fetch failed for Cabinet Housing Decision: Elm Street",
+                timestamp=started_at + timedelta(seconds=75),
+                step_name="document fetch",
+                source_url=source_url,
+                document_url=failed_url,
+                document_title=str(failed_blueprint["title"]),
+                document_type=DocumentType.DECISION.value,
+                progress_current=2,
+                progress_total=total_documents,
+                detail="The source page returned a 504 timeout.",
+            )
+        )
+        return events, documents
+
+    events.append(
+        _build_event(
+            run_id=run_id,
+            event_type="completed",
+            message="Retrieval completed successfully",
+            timestamp=started_at + timedelta(seconds=110),
+            step_name="completed",
+            source_url=source_url,
+            progress_current=total_documents,
+            progress_total=total_documents,
+            detail="Finished fetching and storing all documents for this run.",
+        )
+    )
+    return events, documents
+
+
+def metadata_keys_present(event: AgentEvent) -> bool:
+    metadata = event.metadata or {}
+    return all(key in metadata for key in RETRIEVAL_METADATA_KEYS)

--- a/src/dashboard/state.py
+++ b/src/dashboard/state.py
@@ -1,0 +1,416 @@
+"""Pure helpers for dashboard session state and derived monitoring views."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Iterable, MutableMapping
+from urllib.parse import urlparse
+
+from src.dashboard.constants import (
+    DASHBOARD_CURRENT_RUN_KEY,
+    DASHBOARD_PIPELINE_REQUESTS_KEY,
+    DASHBOARD_REQUEST_SEQUENCE_KEY,
+    DASHBOARD_RUN_DOCUMENTS_KEY,
+    DASHBOARD_RUN_EVENTS_KEY,
+    DASHBOARD_RUN_ORDER_KEY,
+    DASHBOARD_RUN_SEQUENCE_KEY,
+    DASHBOARD_SELECTED_RUN_KEY,
+    DASHBOARD_SUMMARIES_GENERATED_KEY,
+    HISTORY_LIMIT,
+    PIPELINE_STAGES,
+    PLACEHOLDER_STAGE_MESSAGE,
+    STAGE_LABELS,
+)
+from src.models.documents import AgentEvent, CouncilDocument
+
+
+@dataclass(frozen=True)
+class StageSnapshot:
+    stage: str
+    label: str
+    status: str
+    message: str
+    last_updated: datetime | None
+
+
+@dataclass(frozen=True)
+class RunSummary:
+    run_id: str
+    status: str
+    started_at: datetime | None
+    completed_at: datetime | None
+    documents_discovered: int
+    documents_fetched: int
+    errors: int
+    latest_message: str
+    source_url: str | None
+
+
+@dataclass(frozen=True)
+class RetrievalTraceStep:
+    timestamp: datetime
+    step_name: str
+    event_type: str
+    message: str
+    source_url: str | None
+    document_title: str | None
+    document_type: str | None
+    detail: str | None
+
+
+@dataclass(frozen=True)
+class PipelineRequest:
+    request_id: str
+    source_url: str
+    requested_at: datetime
+    status: str
+    message: str
+
+
+SessionState = MutableMapping[str, Any]
+
+
+def initialize_state(state: SessionState) -> None:
+    if _missing_state(state):
+        _replace_dashboard_state(state)
+
+
+def reset_demo_state(state: SessionState) -> None:
+    _replace_dashboard_state(state, force=True)
+
+
+def load_runs(state: SessionState) -> list[RunSummary]:
+    run_events = state.get(DASHBOARD_RUN_EVENTS_KEY, {})
+    run_documents = state.get(DASHBOARD_RUN_DOCUMENTS_KEY, {})
+    summaries: list[RunSummary] = []
+    for run_id in state.get(DASHBOARD_RUN_ORDER_KEY, []):
+        events = run_events.get(run_id, [])
+        documents = run_documents.get(run_id, [])
+        summary = summarize_run(run_id, events, documents)
+        if summary is not None:
+            summaries.append(summary)
+    return sorted(
+        summaries,
+        key=lambda summary: summary.started_at or datetime.min.replace(tzinfo=timezone.utc),
+        reverse=True,
+    )
+
+
+def load_events(state: SessionState, run_id: str | None = None) -> list[AgentEvent]:
+    run_events = state.get(DASHBOARD_RUN_EVENTS_KEY, {})
+    if run_id is not None:
+        return list(run_events.get(run_id, []))
+
+    events: list[AgentEvent] = []
+    for events_for_run in run_events.values():
+        events.extend(events_for_run)
+    return sorted(events, key=lambda event: event.timestamp)
+
+
+def load_documents(state: SessionState, run_id: str | None = None) -> list[CouncilDocument]:
+    run_documents = state.get(DASHBOARD_RUN_DOCUMENTS_KEY, {})
+    if run_id is not None:
+        return list(run_documents.get(run_id, []))
+
+    documents: list[CouncilDocument] = []
+    for documents_for_run in run_documents.values():
+        documents.extend(documents_for_run)
+    return sorted(documents, key=lambda document: document.fetched_at, reverse=True)
+
+
+def load_stage_snapshots(state: SessionState) -> list[StageSnapshot]:
+    current_run_id = get_current_run_id(state)
+    current_run_summary = get_run_summary(state, current_run_id)
+    current_events = load_events(state, current_run_id) if current_run_id else []
+    latest_event = current_events[-1] if current_events else None
+    active_request = get_active_request(state)
+    recent_runs = load_recent_runs(state)
+    latest_run = recent_runs[0] if recent_runs else None
+
+    snapshots: list[StageSnapshot] = []
+    for stage in PIPELINE_STAGES:
+        if stage == "retrieval" and current_run_summary is not None:
+            snapshots.append(
+                StageSnapshot(
+                    stage=stage,
+                    label=STAGE_LABELS[stage],
+                    status=current_run_summary.status,
+                    message=current_run_summary.latest_message,
+                    last_updated=latest_event.timestamp if latest_event else current_run_summary.completed_at,
+                )
+            )
+            continue
+        if stage == "retrieval" and active_request is not None:
+            snapshots.append(
+                StageSnapshot(
+                    stage=stage,
+                    label=STAGE_LABELS[stage],
+                    status="queued",
+                    message=f"Queued manual start from {active_request.source_url}",
+                    last_updated=active_request.requested_at,
+                )
+            )
+            continue
+        if stage == "retrieval":
+            message = "Awaiting manual start URL."
+            last_updated = None
+            if latest_run is not None:
+                message = f"No active run. Last run {latest_run.run_id} finished {latest_run.status}."
+                last_updated = latest_run.completed_at or latest_run.started_at
+            snapshots.append(
+                StageSnapshot(
+                    stage=stage,
+                    label=STAGE_LABELS[stage],
+                    status="idle",
+                    message=message,
+                    last_updated=last_updated,
+                )
+            )
+            continue
+
+        snapshots.append(
+            StageSnapshot(
+                stage=stage,
+                label=STAGE_LABELS[stage],
+                status="placeholder",
+                message=PLACEHOLDER_STAGE_MESSAGE,
+                last_updated=None,
+            )
+        )
+    return snapshots
+
+
+def load_global_metrics(state: SessionState) -> dict[str, Any]:
+    current_run_id = get_current_run_id(state)
+    current_run = get_run_summary(state, current_run_id)
+    recent_runs = load_recent_runs(state)
+    active_request = get_active_request(state)
+    last_run_at = None
+    if current_run is not None:
+        last_run_at = current_run.completed_at or current_run.started_at
+    elif recent_runs:
+        last_run_at = recent_runs[0].completed_at or recent_runs[0].started_at
+
+    active_run_status = "idle"
+    if current_run is not None:
+        active_run_status = current_run.status
+    elif active_request is not None:
+        active_run_status = active_request.status
+
+    return {
+        "active_run_status": active_run_status,
+        "documents_discovered": current_run.documents_discovered if current_run is not None else 0,
+        "documents_fetched": current_run.documents_fetched if current_run is not None else 0,
+        "queued_requests": len(load_pipeline_requests(state)),
+        "summaries_generated": state.get(DASHBOARD_SUMMARIES_GENERATED_KEY, 0),
+        "recent_errors": sum(run.errors for run in recent_runs),
+        "last_run_at": last_run_at,
+    }
+
+
+def load_recent_runs(state: SessionState) -> list[RunSummary]:
+    return load_runs(state)[:HISTORY_LIMIT]
+
+
+def get_current_run_id(state: SessionState) -> str | None:
+    current_run_id = state.get(DASHBOARD_CURRENT_RUN_KEY)
+    if current_run_id in state.get(DASHBOARD_RUN_EVENTS_KEY, {}):
+        return current_run_id
+    return None
+
+
+def get_selected_run_id(state: SessionState) -> str | None:
+    selected_run_id = state.get(DASHBOARD_SELECTED_RUN_KEY)
+    if selected_run_id in state.get(DASHBOARD_RUN_EVENTS_KEY, {}):
+        return selected_run_id
+    recent_runs = load_recent_runs(state)
+    return recent_runs[0].run_id if recent_runs else get_current_run_id(state)
+
+
+def select_run(state: SessionState, run_id: str | None) -> None:
+    if run_id is None or run_id not in state.get(DASHBOARD_RUN_EVENTS_KEY, {}):
+        recent_runs = load_recent_runs(state)
+        state[DASHBOARD_SELECTED_RUN_KEY] = recent_runs[0].run_id if recent_runs else None
+        return
+    state[DASHBOARD_SELECTED_RUN_KEY] = run_id
+
+
+def load_pipeline_requests(state: SessionState) -> list[PipelineRequest]:
+    requests = list(state.get(DASHBOARD_PIPELINE_REQUESTS_KEY, []))
+    return sorted(requests, key=lambda request: request.requested_at, reverse=True)
+
+
+def get_active_request(state: SessionState) -> PipelineRequest | None:
+    requests = load_pipeline_requests(state)
+    return requests[0] if requests else None
+
+
+def submit_pipeline_request(state: SessionState, source_url: str) -> PipelineRequest:
+    initialize_state(state)
+    normalized_url = source_url.strip()
+    parsed = urlparse(normalized_url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise ValueError("Enter a valid http or https URL to start the pipeline.")
+
+    sequence = int(state.get(DASHBOARD_REQUEST_SEQUENCE_KEY, 0)) + 1
+    request = PipelineRequest(
+        request_id=f"request-{sequence:03d}",
+        source_url=normalized_url,
+        requested_at=datetime.now(timezone.utc),
+        status="queued",
+        message="Queued for retrieval agent handoff once the live pipeline is wired.",
+    )
+    state[DASHBOARD_PIPELINE_REQUESTS_KEY].append(request)
+    state[DASHBOARD_REQUEST_SEQUENCE_KEY] = sequence
+    state[DASHBOARD_CURRENT_RUN_KEY] = None
+    return request
+
+
+def summarize_run(
+    run_id: str, events: Iterable[AgentEvent], documents: Iterable[CouncilDocument]
+) -> RunSummary | None:
+    events = list(events)
+    documents = list(documents)
+    if not events:
+        return None
+
+    started_at = min(event.timestamp for event in events)
+    latest_event = max(events, key=lambda event: event.timestamp)
+    status = map_event_type_to_status(latest_event.event_type)
+    completed_at = latest_event.timestamp if status in {"completed", "error"} else None
+    discovered = max(_event_progress_total(event) for event in events)
+    source_url = _latest_non_empty_metadata(events, "source_url")
+
+    return RunSummary(
+        run_id=run_id,
+        status=status,
+        started_at=started_at,
+        completed_at=completed_at,
+        documents_discovered=discovered,
+        documents_fetched=len(documents),
+        errors=sum(1 for event in events if event.event_type == "error"),
+        latest_message=latest_event.message,
+        source_url=source_url,
+    )
+
+
+def get_run_summary(state: SessionState, run_id: str | None) -> RunSummary | None:
+    if run_id is None:
+        return None
+    events = state.get(DASHBOARD_RUN_EVENTS_KEY, {}).get(run_id, [])
+    documents = state.get(DASHBOARD_RUN_DOCUMENTS_KEY, {}).get(run_id, [])
+    return summarize_run(run_id, events, documents)
+
+
+def load_retrieval_overview(state: SessionState, run_id: str | None = None) -> dict[str, Any]:
+    active_request = get_active_request(state)
+    current_run_id = get_current_run_id(state)
+    if run_id is None and current_run_id is None and active_request is not None:
+        return {
+            "run_id": None,
+            "status": active_request.status,
+            "current_step": "queued for start",
+            "current_source_url": active_request.source_url,
+            "documents_discovered": 0,
+            "documents_fetched": 0,
+            "latest_error": None,
+            "summary": None,
+            "active_request": active_request,
+        }
+
+    run_id = run_id or get_selected_run_id(state)
+    summary = get_run_summary(state, run_id)
+    events = load_events(state, run_id)
+    latest_error = next((event.message for event in reversed(events) if event.event_type == "error"), None)
+    latest_event = events[-1] if events else None
+    current_source_url = _latest_non_empty_metadata(events, "source_url")
+    current_step = None
+    if latest_event is not None:
+        current_step = _event_metadata(latest_event).get("step_name")
+    elif active_request is not None:
+        current_step = "queued for start"
+        current_source_url = active_request.source_url
+
+    return {
+        "run_id": run_id,
+        "status": summary.status if summary is not None else active_request.status if active_request else "idle",
+        "current_step": current_step,
+        "current_source_url": current_source_url,
+        "documents_discovered": summary.documents_discovered if summary is not None else 0,
+        "documents_fetched": summary.documents_fetched if summary is not None else 0,
+        "latest_error": latest_error,
+        "summary": summary,
+        "active_request": active_request,
+    }
+
+
+def load_retrieval_trace(state: SessionState, run_id: str | None = None) -> list[RetrievalTraceStep]:
+    events = load_events(state, run_id)
+    trace: list[RetrievalTraceStep] = []
+    for event in events:
+        metadata = _event_metadata(event)
+        trace.append(
+            RetrievalTraceStep(
+                timestamp=event.timestamp,
+                step_name=str(metadata.get("step_name") or "unknown"),
+                event_type=event.event_type,
+                message=event.message,
+                source_url=metadata.get("source_url"),
+                document_title=metadata.get("document_title"),
+                document_type=metadata.get("document_type"),
+                detail=metadata.get("detail"),
+            )
+        )
+    return trace
+
+
+def map_event_type_to_status(event_type: str) -> str:
+    return {
+        "started": "running",
+        "progress": "running",
+        "completed": "completed",
+        "error": "error",
+    }.get(event_type, "idle")
+
+
+def _missing_state(state: SessionState) -> bool:
+    required_keys = (
+        DASHBOARD_RUN_EVENTS_KEY,
+        DASHBOARD_RUN_DOCUMENTS_KEY,
+        DASHBOARD_RUN_ORDER_KEY,
+        DASHBOARD_CURRENT_RUN_KEY,
+        DASHBOARD_SELECTED_RUN_KEY,
+        DASHBOARD_RUN_SEQUENCE_KEY,
+        DASHBOARD_SUMMARIES_GENERATED_KEY,
+        DASHBOARD_PIPELINE_REQUESTS_KEY,
+        DASHBOARD_REQUEST_SEQUENCE_KEY,
+    )
+    return any(key not in state for key in required_keys)
+
+
+def _replace_dashboard_state(state: SessionState, force: bool = False) -> None:
+    from src.dashboard.mock_data import create_seeded_dashboard_data
+
+    seeded = create_seeded_dashboard_data()
+    for key, value in seeded.items():
+        if force or key not in state:
+            state[key] = value
+
+
+def _event_metadata(event: AgentEvent) -> dict[str, Any]:
+    return dict(event.metadata or {})
+
+
+def _event_progress_total(event: AgentEvent) -> int:
+    metadata = _event_metadata(event)
+    value = metadata.get("progress_total")
+    return int(value) if value is not None else 0
+
+
+def _latest_non_empty_metadata(events: Iterable[AgentEvent], key: str) -> str | None:
+    for event in reversed(list(events)):
+        value = _event_metadata(event).get(key)
+        if value:
+            return str(value)
+    return None

--- a/tests/test_dashboard_mock_data.py
+++ b/tests/test_dashboard_mock_data.py
@@ -1,0 +1,42 @@
+"""Tests for seeded dashboard fixtures."""
+
+from src.dashboard.constants import (
+    DASHBOARD_CURRENT_RUN_KEY,
+    DASHBOARD_PIPELINE_REQUESTS_KEY,
+    DASHBOARD_RUN_DOCUMENTS_KEY,
+    DASHBOARD_RUN_EVENTS_KEY,
+    DASHBOARD_RUN_ORDER_KEY,
+    DASHBOARD_SELECTED_RUN_KEY,
+)
+from src.dashboard.mock_data import create_seeded_dashboard_data
+from src.dashboard.simulation import metadata_keys_present
+
+
+def test_seeded_dashboard_data_is_deterministic():
+    first = create_seeded_dashboard_data()
+    second = create_seeded_dashboard_data()
+
+    assert first[DASHBOARD_RUN_ORDER_KEY] == ["run-001", "run-002", "run-003"]
+    assert first[DASHBOARD_RUN_ORDER_KEY] == second[DASHBOARD_RUN_ORDER_KEY]
+    assert first[DASHBOARD_CURRENT_RUN_KEY] is None
+    assert first[DASHBOARD_SELECTED_RUN_KEY] == "run-003"
+    assert first[DASHBOARD_PIPELINE_REQUESTS_KEY] == []
+    assert (
+        first[DASHBOARD_RUN_EVENTS_KEY]["run-003"][-1].timestamp
+        == second[DASHBOARD_RUN_EVENTS_KEY]["run-003"][-1].timestamp
+    )
+
+
+def test_seeded_dashboard_data_has_expected_documents():
+    seeded = create_seeded_dashboard_data()
+
+    assert len(seeded[DASHBOARD_RUN_DOCUMENTS_KEY]["run-001"]) == 3
+    assert len(seeded[DASHBOARD_RUN_DOCUMENTS_KEY]["run-002"]) == 1
+    assert len(seeded[DASHBOARD_RUN_DOCUMENTS_KEY]["run-003"]) == 3
+
+
+def test_seeded_events_use_standard_metadata_keys():
+    seeded = create_seeded_dashboard_data()
+
+    for events in seeded[DASHBOARD_RUN_EVENTS_KEY].values():
+        assert all(metadata_keys_present(event) for event in events)

--- a/tests/test_dashboard_simulation.py
+++ b/tests/test_dashboard_simulation.py
@@ -1,0 +1,30 @@
+"""Tests for retrieval run simulation."""
+
+from datetime import datetime, timezone
+
+from src.dashboard.simulation import create_retrieval_run
+from src.dashboard.state import summarize_run
+
+
+def test_completed_retrieval_run_has_expected_event_sequence():
+    events, documents = create_retrieval_run(
+        "run-010", datetime(2026, 3, 15, 13, 0, tzinfo=timezone.utc), outcome="completed"
+    )
+
+    assert events[0].event_type == "started"
+    assert events[-1].event_type == "completed"
+    assert len(documents) == 3
+
+
+def test_error_retrieval_run_surfaces_error_status():
+    events, documents = create_retrieval_run(
+        "run-011", datetime(2026, 3, 15, 14, 0, tzinfo=timezone.utc), outcome="error"
+    )
+
+    summary = summarize_run("run-011", events, documents)
+
+    assert summary is not None
+    assert summary.status == "error"
+    assert summary.documents_discovered == 3
+    assert summary.documents_fetched == 1
+    assert summary.errors == 1

--- a/tests/test_dashboard_state.py
+++ b/tests/test_dashboard_state.py
@@ -1,0 +1,96 @@
+"""Tests for dashboard state derivation."""
+
+import pytest
+
+from src.dashboard.mock_data import create_seeded_dashboard_data
+from src.dashboard.state import (
+    get_current_run_id,
+    get_selected_run_id,
+    initialize_state,
+    load_global_metrics,
+    load_pipeline_requests,
+    load_recent_runs,
+    load_retrieval_overview,
+    load_retrieval_trace,
+    load_stage_snapshots,
+    select_run,
+    submit_pipeline_request,
+)
+
+
+def test_initialize_state_populates_empty_mapping():
+    state = {}
+
+    initialize_state(state)
+
+    assert get_current_run_id(state) is None
+    assert get_selected_run_id(state) == "run-003"
+    assert len(load_recent_runs(state)) == 3
+
+
+def test_load_stage_snapshots_marks_non_retrieval_stages_as_placeholders():
+    state = create_seeded_dashboard_data()
+
+    stages = load_stage_snapshots(state)
+
+    assert stages[0].stage == "retrieval"
+    assert stages[0].status == "idle"
+    assert all(stage.status == "placeholder" for stage in stages[1:])
+
+
+def test_load_recent_runs_orders_newest_first():
+    state = create_seeded_dashboard_data()
+
+    runs = load_recent_runs(state)
+
+    assert [run.run_id for run in runs] == ["run-003", "run-002", "run-001"]
+    assert runs[1].status == "error"
+
+
+def test_load_global_metrics_uses_current_run_and_recent_errors():
+    state = create_seeded_dashboard_data()
+
+    metrics = load_global_metrics(state)
+
+    assert metrics["active_run_status"] == "idle"
+    assert metrics["documents_discovered"] == 0
+    assert metrics["documents_fetched"] == 0
+    assert metrics["queued_requests"] == 0
+    assert metrics["recent_errors"] == 1
+    assert metrics["last_run_at"] is not None
+
+
+def test_selecting_historical_run_updates_retrieval_overview():
+    state = create_seeded_dashboard_data()
+    select_run(state, "run-002")
+
+    overview = load_retrieval_overview(state, get_selected_run_id(state))
+    trace = load_retrieval_trace(state, "run-002")
+
+    assert overview["run_id"] == "run-002"
+    assert overview["status"] == "error"
+    assert overview["latest_error"] is not None
+    assert trace[-1].event_type == "error"
+
+
+def test_submit_pipeline_request_adds_queued_request():
+    state = create_seeded_dashboard_data()
+
+    request = submit_pipeline_request(state, "https://committees.westminster.gov.uk/custom-source")
+
+    requests = load_pipeline_requests(state)
+    overview = load_retrieval_overview(state, None)
+    stages = load_stage_snapshots(state)
+
+    assert request.request_id == "request-001"
+    assert requests[0].source_url == "https://committees.westminster.gov.uk/custom-source"
+    assert overview["status"] == "queued"
+    assert overview["active_request"] is not None
+    assert stages[0].status == "queued"
+
+
+def test_submit_pipeline_request_rejects_invalid_url():
+    state = create_seeded_dashboard_data()
+
+    with pytest.raises(ValueError):
+        submit_pipeline_request(state, "not-a-url")


### PR DESCRIPTION
## Summary
- build a monitoring-first Streamlit dashboard for pipeline oversight
- add retrieval-specific drill-down views, seeded historical runs, and event-driven metrics
- replace the simulated run trigger with a manual URL-based pipeline start request queue
- add centralized dashboard state/mock/simulation helpers and test coverage

## Scope
This is step 1 of issue #2.

Implemented here:
- pipeline overview cards for retrieval, analysis, conversation, app, and summary
- current retrieval status panel plus historical run inspection
- queued pipeline start requests from a user-provided URL
- selected-run and global event logs
- mock-backed retrieval history and retrieval trace visibility

Deferred:
- live handoff from queued URL to the retrieval agent in #1/#3
- voter and councillor interaction flows from the broader workstream

## Testing
- `pytest -q`

Refs #2
